### PR TITLE
make normalise always write to filename.png, just like NodeBB core does.

### DIFF
--- a/library.js
+++ b/library.js
@@ -53,16 +53,12 @@ plugin.fileTypeAllowed = function(path, callback) {
 };
 
 plugin.normalise = function(data, callback) {
-	if(data.extension !== '.png') {
-		gm(data.path).toBuffer('png', function(err, buffer) {
-			if (err) {
-				return callback(err);
-			}
-			fs.writeFile(data.path, buffer, 'binary', callback);
-		});
-	} else {
-		callback();
-	}
+	gm(data.path).toBuffer('png', function(err, buffer) {
+		if (err) {
+			return callback(err);
+		}
+		fs.writeFile(data.path + '.png', buffer, 'binary', callback);
+	});
 };
 
 module.exports = plugin;


### PR DESCRIPTION
Reference for NodeBB core behavior:

https://github.com/NodeBB/NodeBB/blob/v1.0.3/src/image.js#L62-L80
